### PR TITLE
Add to doclets (JSDoc CI)

### DIFF
--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,0 +1,4 @@
+dir: src
+articles:
+ 	- Readme: README.md
+ 	- Changelog: CHANGELOG.md

--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,4 +1,4 @@
 dir: src
 articles:
- 	- Readme: README.md
- 	- Changelog: CHANGELOG.md
+  - Readme: README.md
+  - Changelog: CHANGELOG.md


### PR DESCRIPTION
Adds documentation to doclets.io service. Future tags and master branch will be published automatically.

[Preview generated with my account](https://doclets.io/lipp/JSNetworkX/add-to-doclets)

@fkling If you like this, you are very welcomed to login to https://doclets.io with GitHub OAuth. If you don't like it, I'd be happy to hear what you don't like about it :)

Steps required (3min):
1) @fkling  logs in to doclets.io
2) @fkling  adds JSNetworkX
3) @fkling  merges this PR
