### PR TITLE
Bump lodash from 3.3.1 to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "node/index.js",
   "dependencies": {
     "babel-runtime": "^5",
-    "lodash": "^3.3.1",
+    "lodash": "^4.17.21",
     "through": "^2.3.6",
     "tiny-sprintf": "^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "email": "felix.kling@gmx.net",
     "url": "http://jsnetworkx.org/"
   },
-  "main": "node/index.js",
+  "main": "jsnetworkx.js",
   "dependencies": {
     "babel-runtime": "^5",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Modified entry point to align with the package name. Installing jsnetworkx places the entry point in node_modules/jsnetworkx/jsnetworkx.js.  As a result, I changed "main": "node/index.js" to "main": "jsnetworkx.js" in package.json.

I also updated the Lodash dependency to 4.17.21 as Lodash versions before 4.17.21 are vulnerable to Command Injection via the template function.

**Potential issues**

When I imported the package into my react component via;

`import * as jsnx from "jsnetworkx";`

And hover over "jsnetworkx" There is a warning message which may or may not be problematic; 

"Could not find a declaration file for module 'jsnetworkx'. 'c:/Users/joshm/Desktop/Coding/CS50W/Final Project/AlgorithmVisualizer/frontend/node_modules/jsnetworkx/jsnetworkx.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/jsnetworkx` if it exists or add a new declaration (.d.ts) file containing `declare module 'jsnetworkx';`ts(7016)"

Even with this occurring, I am having zero problems so far with the updated version.

Here is an image of my projects import to node_modules for reference;

![node_modules](https://github.com/fkling/JSNetworkX/assets/129724803/8c4cd810-c867-44aa-802a-bbd2d75757a1)